### PR TITLE
Cleanup after pipedrive change

### DIFF
--- a/_coaching/recruiting-and-hiring-for-distributed-government-teams.md
+++ b/_coaching/recruiting-and-hiring-for-distributed-government-teams.md
@@ -10,7 +10,7 @@ author:
   - johnoduinn
 service_about: This one-on-one coaching builds on previous training, and will help you solve your agency’s specific implementation challenges around hiring for distributed (remote / telework) teams. Modernizing your recruiting, hiring, and onboarding processes to work well in a virtual environment will increase your team’s resilience, diversity, and retention.
 cost: Varies according to duration and complexity of engagement
-form: /request
+form: /contact
 categories:
   - Communications
   - Culture

--- a/_coaching/working-and-leading-in-distributed-teams.md
+++ b/_coaching/working-and-leading-in-distributed-teams.md
@@ -8,7 +8,7 @@ excerpt:
 author: johnoduinn
 service_about: This one-on-one coaching builds on previous training, and will help you with any agency specific implementation questions you might encounter while building effective distributed (remote / teleworking) teams. From team culture and communication issues to policy and operational headaches, we provide personalized support to help you overcome challenges and empower happy and productive teleworking teams.
 cost: Varies according to duration and complexity of engagement
-form: /request
+form: /contact
 categories:
   -  Communications
   -  Culture

--- a/_consulting/designing-and-writing-effective-telework-policies.md
+++ b/_consulting/designing-and-writing-effective-telework-policies.md
@@ -8,7 +8,7 @@ excerpt:
 author: johnoduinn
 service_about: Developing telework policies that evolve with operational and technical needs is essential for long-term resilience in the event of prolonged government office closures or scaling telework opportunities to build a more diverse, effective, and modern workforce. We consult with executives to create or revise their telework policies in accordance with best practices for distributed teams, helping you navigate the complexities of security, training certifications, scalability, and performance measurement.
 cost: Estimated at $31,680. This is for a 12-week engagement, 4 hours per week at $660 per hour. To speed up this complex, custom process, we use common patterns and established best practices wherever applicable.
-form: /request
+form: /contact
 categories:
   -  Managing
   -  Policy

--- a/_training/effective-telework-in-distributed-government-teams.md
+++ b/_training/effective-telework-in-distributed-government-teams.md
@@ -8,7 +8,7 @@ excerpt:
 author: johnoduinn
 service_about: This training provides government teams with strategies, tools, and best practices for working together effectively in a distributed (remote/telework) model. These skills increase your agency’s resilience by improving team performance, streamlining communications, and modernizing workflows for better collaboration.
 cost: $250 per participant, for up to 200 people (minimum 175 people per cohort)
-form: /request
+form: /contact
 categories:
   - Communications
   - Culture

--- a/_training/humanware-helping-teams-work-better-together.md
+++ b/_training/humanware-helping-teams-work-better-together.md
@@ -10,7 +10,7 @@ author:
   - joanbordow
 service_about: Excellence and competency are not the only factors that contribute to the successful performance of a team. Human dynamics play a crucial role, such as a team’s ability to effectively communicate and coordinate with each other, to overcome everyday adversity, and ⁠— most importantly ⁠— to do these things well under pressure. This training provides government teams with a proven team dynamics methodology for excelling at work.
 cost: $1,000 per participant
-form: /request
+form: /contact
 categories:
   -  Communications
   -  Culture

--- a/_training/introduction-to-effective-telework-in-government.md
+++ b/_training/introduction-to-effective-telework-in-government.md
@@ -8,8 +8,7 @@ excerpt:
 author: johnoduinn
 service_about: This webinar will introduce high-level strategies and practical tips to help government teams work effectively together while physically apart. Presented by John O’Duinn, author of “Distributed Teams.”
 cost: FREE 
-form: https://civicactions.zoom.us/meeting/register/tJ0tc-2rqDwoE9MmquuSu426qAyDK90f3zn5
-form_text: Register
+form: /contact
 categories:
   -  Communications
   -  Culture

--- a/_training/managing-teleworkers-in-government.md
+++ b/_training/managing-teleworkers-in-government.md
@@ -8,7 +8,7 @@ excerpt:
 author: johnoduinn
 service_about: This training provides government leaders with strategies, tools, and best practices for effectively leading in a distributed (remote/telework) model. The focus is on the unique challenges of leading, mentoring, and managing while physically apart from your team.
 cost: $20,000 for up to 20 participants
-form: /request
+form: /contact
 categories:
   -  Communications
   -  Culture

--- a/_training/overview-longterm-strategy.md
+++ b/_training/overview-longterm-strategy.md
@@ -8,7 +8,7 @@ excerpt:
 author: johnoduinn
 service_about: This online training introduces government leaders to the strategies, tools, and best practices for effectively leading in a distributed (remote/telework) model -- and showcases the benefits of adopting telework as a viable long term strategy. The focus is on the unique challenges of leading, mentoring, and managing while physically apart from your team for prolonged periods of time. 
 cost: $2,000 for up to 100 participants
-form: /request
+form: /contact
 categories:
   -  Communications
   -  Culture

--- a/_training/recruiting-and-hiring-while-teleworking.md
+++ b/_training/recruiting-and-hiring-while-teleworking.md
@@ -10,7 +10,7 @@ author:
   - johnoduinn
 service_about: Recruiting and hiring while your team is teleworking can be challenging — but it’s also an opportunity to gain the benefits that distributed teams can bring to your agency. This training empowers agency staff to securely and effectively interview and onboard new team members in virtual environments.
 cost: $20,000 for up to 20 participants
-form: /request
+form: /contact
 categories:
   -  Communications
   -  Hiring

--- a/_training/running-large-online-government-meetings.md
+++ b/_training/running-large-online-government-meetings.md
@@ -8,7 +8,7 @@ excerpt:
 author: johnoduinn
 service_about: Government leaders hold various types of large scale meetings — from team communications and milestones to open “town-hall” style meetings with stakeholders or the public. Learn how to run these meetings online instead of in person, with consideration for security, technology, audience engagement, and logistics.
 cost: $20,000 for up to 20 participants
-form: /request
+form: /contact
 categories:
   -  Communications
   -  Meetings


### PR DESCRIPTION
1) change offering to use working contact page (not broken-pipedrive-request page)

2) for one-off event last year, remove broken zoom link. Separate discussion to follow about removing this event completely vs doing it again.